### PR TITLE
Fix invalid user in chown command

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -60,7 +60,6 @@ if [ ! -f "$BACKEND_DIR/.env" ]; then
     print_warning ".env file not found. Creating from template..."
     if [ -f "$BACKEND_DIR/.env.example" ]; then
         cp "$BACKEND_DIR/.env.example" "$BACKEND_DIR/.env"
-        chown ubuntu:ubuntu "$BACKEND_DIR/.env"
         print_status "Please edit $BACKEND_DIR/.env with your configuration"
     else
         print_error "No .env.example file found"
@@ -107,26 +106,15 @@ pm2 delete visipakalpojumi-backend 2>/dev/null || true
 
 # Create logs directory if it doesn't exist
 mkdir -p "$APP_DIR/logs"
-chown ubuntu:ubuntu "$APP_DIR/logs"
 
 # Start the backend application with PM2
 print_status "Starting backend application..."
-if [[ $EUID -eq 0 ]]; then
-    pm2 start "npm run start" \
-        --name "visipakalpojumi-backend" \
-        --cwd "$BACKEND_DIR" \
-        --env production \
-        --log "$APP_DIR/logs/backend.log" \
-        --error "$APP_DIR/logs/backend-error.log" \
-        --uid ubuntu
-else
-    pm2 start "npm run start" \
-        --name "visipakalpojumi-backend" \
-        --cwd "$BACKEND_DIR" \
-        --env production \
-        --log "$APP_DIR/logs/backend.log" \
-        --error "$APP_DIR/logs/backend-error.log"
-fi
+pm2 start "npm run start" \
+    --name "visipakalpojumi-backend" \
+    --cwd "$BACKEND_DIR" \
+    --env production \
+    --log "$APP_DIR/logs/backend.log" \
+    --error "$APP_DIR/logs/backend-error.log"
 
 # Save PM2 configuration
 pm2 save
@@ -298,7 +286,6 @@ fi
 # Create uploads directory
 mkdir -p "$APP_DIR/uploads"
 chmod 755 "$APP_DIR/uploads"
-chown ubuntu:ubuntu "$APP_DIR/uploads"
 
 # Wait for application to start
 print_status "Waiting for application to start..."


### PR DESCRIPTION
Remove `chown ubuntu:ubuntu` commands and PM2 `--uid ubuntu` parameter to resolve "invalid user" errors when running the script as root.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c7b0aef-4661-4584-9276-407f76585a31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c7b0aef-4661-4584-9276-407f76585a31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

