### PR TITLE
Allow external access to frontend server

### DIFF
--- a/start-frontend.sh
+++ b/start-frontend.sh
@@ -71,7 +71,7 @@ start_frontend() {
     npm run build
     
     print_status "Starting Next.js standalone server..."
-    nohup node .next/standalone/server.js > "$APP_DIR/logs/frontend.log" 2>&1 &
+    nohup env HOSTNAME=0.0.0.0 node .next/standalone/server.js > "$APP_DIR/logs/frontend.log" 2>&1 &
     FRONTEND_PID=$!
     
     # Wait for frontend to start

--- a/start-full.sh
+++ b/start-full.sh
@@ -277,7 +277,7 @@ start_frontend() {
     # Start the frontend production server
     print_status "Starting Next.js standalone server..."
     cd "$FRONTEND_DIR"
-    nohup node .next/standalone/server.js > "$APP_DIR/logs/frontend.log" 2> "$APP_DIR/logs/frontend-error.log" &
+    nohup env HOSTNAME=0.0.0.0 node .next/standalone/server.js > "$APP_DIR/logs/frontend.log" 2> "$APP_DIR/logs/frontend-error.log" &
     FRONTEND_PID=$!
     
     # Wait for frontend to start


### PR DESCRIPTION
Configure Next.js frontend to listen on all network interfaces by setting `HOSTNAME=0.0.0.0`.

Previously, the Next.js server only bound to `127.0.0.1`, preventing external access. This change allows the server to be reached via the server's IP address.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0d9a2fb-ff4b-417c-9d15-9d9f3111066e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0d9a2fb-ff4b-417c-9d15-9d9f3111066e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

